### PR TITLE
Allow moving to specified status when merged or closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ Currently this action needs a permanent token as it does not support the wrike O
 
 Once you have a token, add it to your repository at Settings > Secrets.
 
+### Inputs
+
+Optionally you can specify (by name) what status you'd want to move the linked task to.
+
+#### `merged`
+
+Specifies the status to move the task to when the linked PR is merged.
+
+If not specified or not found, falls back to the first Completed status in your workflow.
+
+#### `closed`
+
+Specifies the status to move the task to when the linked PR is closed without merging.
+
+If not specified or not found, falls back to the first Cancelled status in your workflow.
+
 ## Development
 
 ```shell

--- a/action.yaml
+++ b/action.yaml
@@ -6,3 +6,10 @@ runs:
 branding:
   color: green
   icon: check-square
+inputs:
+  merged:
+    required: false
+    description: Status to move task to when the PR is merged. Defaults to the first Completed status in your workflow.
+  closed:
+    required: false
+    description: Status to move task to when the PR is closed without merging. Defaults to the first Cancelled status in your workflow.

--- a/src/wrike_ist/core.cljs
+++ b/src/wrike_ist/core.cljs
@@ -22,8 +22,8 @@
       (if-let [{:keys [state] :as details} (extract-details pr)]
         (-> (case state
               :open (wrike/link-pr details)
-              :merged (wrike/complete-task details)
-              :closed (wrike/cancel-task details)
+              :merged (wrike/complete-task details (core/getInput "merged"))
+              :closed (wrike/cancel-task details (core/getInput "closed"))
               (js/Promise.resolve))
             (.catch #(core/setFailed (.-message %))))
         (js/console.log "Not task link in PR text"))

--- a/src/wrike_ist/wrike.cljs
+++ b/src/wrike_ist/wrike.cljs
@@ -80,7 +80,7 @@
    (folder-statuses folder-id)
    (fn [statuses]
      (reduce
-      (fn [candidate {:strs [name group] :as status}]
+      (fn [candidate {:strs [name] :as status}]
         ;; use the status with the desired name
         ;; or if not found use the first status in the desired group
         ;; or if not found use the last status found

--- a/src/wrike_ist/wrike.cljs
+++ b/src/wrike_ist/wrike.cljs
@@ -75,22 +75,28 @@
                  (filter #(= (get % "hidden") false) statuses))))))
 
 (defn next-status
-  [folder-id wanted-group]
+  [folder-id {:keys [wanted-status wanted-group]}]
   (.then
    (folder-statuses folder-id)
    (fn [statuses]
      (reduce
-      (fn [_candidate {:strs [group] :as status}]
-        ;; use the first status in the desired group, or the last one
-        (if (= group wanted-group)
+      (fn [candidate {:strs [name group] :as status}]
+        ;; use the status with the desired name
+        ;; or if not found use the first status in the desired group
+        ;; or if not found use the last status found
+        (if (= name wanted-status)
           (reduced status)
-          status))
+          (if (= (get candidate "group") wanted-group)
+            candidate
+            status)))
+      ;; start with empty so that the very first status can be candidate too
+      {}
       statuses))))
 
 (defn update-task-status
-  [{task-id "id" [folder-id] "parentIds"} wanted-group]
+  [{task-id "id" [folder-id] "parentIds"} wanted]
   (.then
-   (next-status folder-id wanted-group)
+   (next-status folder-id wanted)
    (fn [{:strs [id]}]
      (let [uri (str "https://www.wrike.com/api/v4/tasks/" task-id)
            params (clj->js {:customStatus id})]
@@ -98,13 +104,15 @@
                       :body (js/JSON.stringify params)})))))
 
 (defn complete-task
-  [{:keys [permalink]}]
+  [{:keys [permalink]} wanted-status]
   (.then
    (find-task permalink)
-   #(update-task-status % "Completed")))
+   #(update-task-status % {:wanted-status wanted-status
+                           :wanted-group "Completed"})))
 
 (defn cancel-task
-  [{:keys [permalink]}]
+  [{:keys [permalink]} wanted-status]
   (.then
    (find-task permalink)
-   #(update-task-status % "Cancelled")))
+   #(update-task-status % {:wanted-status wanted-status
+                           :wanted-group "Cancelled"})))


### PR DESCRIPTION
# Issue

Closes #15 

# What

Use Action inputs to specify by name what status to move the linked task to when the linked PR is closed (with or without merging)